### PR TITLE
fix the allowReadOnlyMutablePaths 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,8 +261,7 @@
                 <executions>
                     <execution>
                         <goals>
-                            <goal>install</goal>
-                            <goal>run</goal>
+
                         </goals>
                         <configuration>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,8 @@
                 <executions>
                     <execution>
                         <goals>
-
+                            <goal>install</goal>
+                            <goal>run</goal>
                         </goals>
                         <configuration>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>

--- a/src/main/java/biz/netcentric/filevault/validator/aem/cloud/AemCloudValidator.java
+++ b/src/main/java/biz/netcentric/filevault/validator/aem/cloud/AemCloudValidator.java
@@ -96,7 +96,7 @@ public class AemCloudValidator implements NodePathValidator, MetaInfPathValidato
                 hasMutableNodes = true;
                 if (numVarNodeViolations < MAX_NUM_VIOLATIONS_PER_TYPE && !isPathWritableByDistributionJournalImporter(path)) {
                     // check if package itself is only used on author
-                    if (!allowReadOnlyMutablePaths || !isContainedInAuthorOnlyPackage(containerValidationContext)) {
+                    if (!allowReadOnlyMutablePaths && !isContainedInAuthorOnlyPackage(containerValidationContext)) {
                         // only emit once per package
                         messages.add(new ValidationMessage(defaultSeverity, String.format(
                                 VIOLATION_MESSAGE_READONLY_MUTABLE_PATH, allowReadOnlyMutablePaths ? VIOLATION_MESSAGE_CONDITION_AUTHOR_ONLY_CONTAINER

--- a/src/main/java/biz/netcentric/filevault/validator/aem/cloud/AemCloudValidatorFactory.java
+++ b/src/main/java/biz/netcentric/filevault/validator/aem/cloud/AemCloudValidatorFactory.java
@@ -46,7 +46,7 @@ public class AemCloudValidatorFactory implements ValidatorFactory {
         if (settings.getOptions().containsKey(OPTION_ALLOW_LIBS_NODE)) {
             allowLibsNode = Boolean.parseBoolean(settings.getOptions().get(OPTION_ALLOW_LIBS_NODE));
         }
-        return new AemCloudValidator(allowReadOnlyMutablePaths, allowLibsNode, context.getProperties().getPackageType(), context.getContainerValidationContext(), settings.getDefaultSeverity());
+            return new AemCloudValidator(allowReadOnlyMutablePaths, allowLibsNode, context.getProperties().getPackageType(), context.getContainerValidationContext(), settings.getDefaultSeverity());
     }
 
     @Override

--- a/src/test/java/biz/netcentric/filevault/validator/aem/cloud/AemCloudValidatorTest.java
+++ b/src/test/java/biz/netcentric/filevault/validator/aem/cloud/AemCloudValidatorTest.java
@@ -13,8 +13,14 @@ package biz.netcentric.filevault.validator.aem.cloud;
  * #L%
  */
 
-import java.nio.file.Paths;
+import static biz.netcentric.filevault.validator.aem.cloud.AemCloudValidator.VIOLATION_MESSAGE_READONLY_MUTABLE_PATH;
 
+import java.nio.file.Paths;
+import java.util.Collection;
+
+import org.apache.jackrabbit.vault.packaging.PackageType;
+import org.apache.jackrabbit.vault.validation.spi.ValidationMessage;
+import org.apache.jackrabbit.vault.validation.spi.ValidationMessageSeverity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -46,4 +52,22 @@ class AemCloudValidatorTest {
         Assertions.assertFalse(AemCloudValidator.isPathWritableByDistributionJournalImporter("/var"));
         Assertions.assertFalse(AemCloudValidator.isPathWritableByDistributionJournalImporter("/var/subnode/myfile"));
     }
+
+
+    @Test
+    void testMutablePaths(){
+        AemCloudValidator validator= new AemCloudValidator(false,false, PackageType.CONTENT,null, ValidationMessageSeverity.ERROR);
+        Collection<ValidationMessage> messages = validator.validate("/var/subnode");
+        Assertions.assertFalse(messages.isEmpty());
+    }
+
+    @Test
+    void testAllowReadOnlyMutablePaths(){
+
+        AemCloudValidator validator= new AemCloudValidator(true,false, PackageType.CONTENT,null, ValidationMessageSeverity.ERROR);
+        Collection<ValidationMessage> messages = validator.validate("/var/subnode");
+        Assertions.assertTrue(messages.isEmpty());
+
+    }
+
 }


### PR DESCRIPTION
The allowReadOnlyMutablePaths flags was not working since the validator always checked for the package to be author-only.
Now the option will allow mutable paths  in any case if set to true