### PR TITLE
Update index definition naming validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ Currently only Oak index definitions of type `lucene` are supported in AEMaaCS. 
 
 ## Follow naming policy for Oak index definition node names
 
-There is a mandatory naming policy for Oak index definition node names which enforces them to end with `-custom-<version-as-integer>`. The format is used in [`IndexName`](https://github.com/apache/jackrabbit-oak/blob/08c7b20e0676739d9c445b5249c3f71004b6b894/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/IndexName.java#L36) and allows for upgrades of existing index definitions in blue/green deployments.
+There is a mandatory naming policy for Oak index definition node names which enforces them to either comply with pattern `<indexName>-<productVersion>-custom-<customVersion>` (customized OOTB index) or `<prefix>.<indexName>-<productVersion>-custom-<customVersion>` (fully customized index). The format is used in [`IndexName`](https://github.com/apache/jackrabbit-oak/blob/08c7b20e0676739d9c445b5249c3f71004b6b894/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/IndexName.java#L36) and allows for upgrades of existing index definitions in blue/green deployments.
 
-Further details in <https://experienceleague.adobe.com/docs/experience-manager-cloud-service/operations/indexing.html?lang=en#changes-in-aem-as-a-cloud-service>.
+Further details in <https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/operations/indexing#preparing-the-new-index-definition>.
 
 # Usage with Maven
 
-You can use this validator with the [FileVault Package Maven Plugin][3] in version 1.1.0 or higher like this
+You can use this validator with the [FileVault Package Maven Plugin][3] in version 1.4.0 or higher like this
 
 ```
 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
 
     <properties>
         <maven.version>3.5.4</maven.version>
+        <jackrabbit.version>2.20.8</jackrabbit.version><!-- minimum Jackrabbit API version supported by the referenced filevault artifact -->
         <java.target.version>8</java.target.version> <!-- used for compiler plugin, javadoc plugin and animal-sniffer, for compatibility reasons with Java 9 only the values 6,7,8 and 9 is allowed -->
         <maven.compiler.release>${java.target.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -61,7 +62,7 @@
         <dependency>
             <groupId>org.apache.jackrabbit.vault</groupId>
             <artifactId>vault-validation</artifactId>
-            <version>3.4.2</version>
+            <version>3.8.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -102,15 +103,19 @@
         </dependency>
         <!-- only transitive dependencies of 'vault-validation' but must be declared due to https://issues.apache.org/jira/browse/JCRVLT-394 -->
         <dependency>
+          <groupId>org.apache.jackrabbit</groupId>
+          <artifactId>jackrabbit-spi-commons</artifactId>
+          <version>${jackrabbit.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.jackrabbit</groupId>
+          <artifactId>jackrabbit-jcr-commons</artifactId>
+          <version>${jackrabbit.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.jcr</groupId>
             <artifactId>jcr</artifactId>
             <version>2.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>jackrabbit-jcr-commons</artifactId>
-            <version>2.20.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Adobe updated the policy in
https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/operations/indexing#preparing-the-new-index-definition

Add unit tests

This closes #33